### PR TITLE
Adding Locked Chest

### DIFF
--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -2,6 +2,7 @@
 blocked:
     - FURNACE
     - CHEST
+    - TRAPPED_CHEST
     - BEACON
     - DISPENSER
     - DROPPER


### PR DESCRIPTION
Locked chest was missing from the file and so so event fired when clicking on the chest with armor in hand.